### PR TITLE
Make CI build actually fail on errors.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,7 @@
 name: documentation
 
 on:
+  pull_request:
   push:
     branches: [ main ]
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going -n
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
Previously build errors get logged, but the overall build status was listed as success.